### PR TITLE
Path sanitization2

### DIFF
--- a/src/llama_stack/core/conversations/conversations.py
+++ b/src/llama_stack/core/conversations/conversations.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from pydantic import BaseModel, TypeAdapter
 
+from llama_stack.core.conversations.validation import CONVERSATION_ID_PATTERN
 from llama_stack.core.datatypes import AccessRule, StackConfig
 from llama_stack.core.storage.sqlstore.authorized_sqlstore import AuthorizedSqlStore
 from llama_stack.core.storage.sqlstore.sqlstore import sqlstore_impl
@@ -182,9 +183,13 @@ class ConversationServiceImpl(Conversations):
         return ConversationDeletedResource(id=request.conversation_id)
 
     def _validate_conversation_id(self, conversation_id: str) -> None:
-        """Validate conversation ID format."""
-        if not conversation_id.startswith("conv_"):
-            raise InvalidParameterError("conversation_id", conversation_id, "Conversation ID must begin with 'conv_'.")
+        """Validate conversation ID format matches ``conv_`` + 48 hex chars."""
+        if not CONVERSATION_ID_PATTERN.fullmatch(conversation_id):
+            raise InvalidParameterError(
+                "conversation_id",
+                conversation_id,
+                "Conversation ID must match format 'conv_' followed by 48 hex characters.",
+            )
 
     def _get_or_generate_item_id(self, item: ConversationItem, item_dict: dict) -> str:
         """Get existing item ID or generate one if missing."""

--- a/src/llama_stack/core/conversations/conversations.py
+++ b/src/llama_stack/core/conversations/conversations.py
@@ -188,7 +188,7 @@ class ConversationServiceImpl(Conversations):
             raise InvalidParameterError(
                 "conversation_id",
                 conversation_id,
-                "Conversation ID must match format 'conv_' followed by 48 hex characters.",
+                "Conversation ID must match format 'conv_' followed by 48 lowercase hex characters.",
             )
 
     def _get_or_generate_item_id(self, item: ConversationItem, item_dict: dict) -> str:

--- a/src/llama_stack/core/conversations/validation.py
+++ b/src/llama_stack/core/conversations/validation.py
@@ -1,0 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import re
+
+CONVERSATION_ID_PATTERN = re.compile(r"^conv_[0-9a-f]{48}$")

--- a/src/llama_stack/providers/inline/agents/meta_reference/responses/openai_responses.py
+++ b/src/llama_stack/providers/inline/agents/meta_reference/responses/openai_responses.py
@@ -622,7 +622,7 @@ class OpenAIResponsesImpl:
                 raise InvalidParameterError(
                     "conversation",
                     conversation,
-                    "Must match format 'conv_' followed by 48 hex characters.",
+                    "Must match format 'conv_' followed by 48 lowercase hex characters.",
                 )
 
         if max_tool_calls is not None and max_tool_calls < 1:

--- a/src/llama_stack/providers/inline/agents/meta_reference/responses/openai_responses.py
+++ b/src/llama_stack/providers/inline/agents/meta_reference/responses/openai_responses.py
@@ -12,6 +12,7 @@ from collections.abc import AsyncIterator
 
 from pydantic import BaseModel, TypeAdapter
 
+from llama_stack.core.conversations.validation import CONVERSATION_ID_PATTERN
 from llama_stack.log import get_logger
 from llama_stack.providers.utils.responses.responses_store import (
     ResponsesStore,
@@ -617,8 +618,12 @@ class OpenAIResponsesImpl:
                     "Provide only one of these parameters.",
                 )
 
-            if not conversation.startswith("conv_"):
-                raise InvalidParameterError("conversation", conversation, "Expected an ID that begins with 'conv_'.")
+            if not CONVERSATION_ID_PATTERN.fullmatch(conversation):
+                raise InvalidParameterError(
+                    "conversation",
+                    conversation,
+                    "Must match format 'conv_' followed by 48 hex characters.",
+                )
 
         if max_tool_calls is not None and max_tool_calls < 1:
             raise ValueError(f"Invalid {max_tool_calls=}; should be >= 1")

--- a/src/llama_stack/providers/inline/files/localfs/files.py
+++ b/src/llama_stack/providers/inline/files/localfs/files.py
@@ -15,8 +15,10 @@ Security boundaries
   sequences, null bytes, and any non-hex characters.
 * **Path containment** -- ``_validate_path_containment`` resolves symlinks and
   ``..`` components, then verifies the result stays inside ``storage_dir``.
-* **Filename sanitization** -- ``Content-Disposition`` filenames are stripped of
-  path separators, traversal sequences, null bytes, and non-ASCII-safe chars.
+* **Filename sanitization** -- User-supplied filenames are sanitized at upload
+  time before being stored in the database or returned in API responses.  The
+  same sanitizer is applied again in the ``Content-Disposition`` header on
+  download as a belt-and-suspenders measure.
 """
 
 import re
@@ -156,6 +158,7 @@ class LocalfsFilesImpl(Files):
 
         file_id = self._generate_file_id()
         file_path = self._get_file_path(file_id)
+        sanitized_name = sanitize_content_disposition_filename(file.filename or "uploaded_file")
 
         content = await file.read()
         file_size = len(content)
@@ -170,7 +173,7 @@ class LocalfsFilesImpl(Files):
             "openai_files",
             {
                 "id": file_id,
-                "filename": file.filename or "uploaded_file",
+                "filename": sanitized_name,
                 "purpose": purpose.value,
                 "bytes": file_size,
                 "created_at": created_at,
@@ -181,7 +184,7 @@ class LocalfsFilesImpl(Files):
 
         return OpenAIFileObject(
             id=file_id,
-            filename=file.filename or "uploaded_file",
+            filename=sanitized_name,
             purpose=purpose,
             bytes=file_size,
             created_at=created_at,

--- a/src/llama_stack/providers/inline/files/localfs/files.py
+++ b/src/llama_stack/providers/inline/files/localfs/files.py
@@ -4,6 +4,22 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+"""Local-filesystem files provider with defense-in-depth path security.
+
+Security boundaries
+-------------------
+* **Indirect references** -- Clients address files via opaque IDs
+  (``file-<1-64 hex chars>``), never raw paths.
+* **ID format validation** -- ``_validate_file_id`` rejects any ID that does
+  not match ``^file-[0-9a-f]{1,64}$``, blocking path separators, traversal
+  sequences, null bytes, and any non-hex characters.
+* **Path containment** -- ``_validate_path_containment`` resolves symlinks and
+  ``..`` components, then verifies the result stays inside ``storage_dir``.
+* **Filename sanitization** -- ``Content-Disposition`` filenames are stripped of
+  path separators, traversal sequences, null bytes, and non-ASCII-safe chars.
+"""
+
+import re
 import time
 import uuid
 from pathlib import Path
@@ -16,9 +32,11 @@ from llama_stack.core.id_generation import generate_object_id
 from llama_stack.core.storage.sqlstore.authorized_sqlstore import AuthorizedSqlStore
 from llama_stack.core.storage.sqlstore.sqlstore import sqlstore_impl
 from llama_stack.log import get_logger
+from llama_stack.providers.utils.files.sanitize import sanitize_content_disposition_filename
 from llama_stack_api import (
     DeleteFileRequest,
     Files,
+    InvalidParameterError,
     ListFilesRequest,
     ListOpenAIFileResponse,
     OpenAIFileDeleteResponse,
@@ -67,16 +85,46 @@ class LocalfsFilesImpl(Files):
     async def shutdown(self) -> None:
         pass
 
+    _FILE_ID_PATTERN = re.compile(r"^file-[0-9a-f]{1,64}$")
+
     def _generate_file_id(self) -> str:
         """Generate a unique file ID for OpenAI API."""
         return generate_object_id("file", lambda: f"file-{uuid.uuid4().hex}")
 
+    def _validate_file_id(self, file_id: str) -> None:
+        """Validate that file_id contains only safe characters (hex digits) after the ``file-`` prefix."""
+        if not self._FILE_ID_PATTERN.fullmatch(file_id):
+            raise InvalidParameterError(
+                "file_id", file_id, "Must match format 'file-' followed by 1-64 hex characters."
+            )
+
+    def _validate_path_containment(self, file_path: Path) -> Path:
+        """Canonicalize *file_path* and verify it resides inside storage_dir.
+
+        Returns the resolved (absolute, symlink-free) path so callers operate
+        on the canonical location.  Raises ``InvalidParameterError`` when the
+        resolved path escapes the storage directory boundary.
+        """
+        resolved = file_path.resolve()
+        storage_dir = Path(self.config.storage_dir).resolve()
+        if not resolved.is_relative_to(storage_dir):
+            raise InvalidParameterError(
+                "file_path",
+                file_path.name,
+                "File path does not resolve to a valid storage location.",
+            )
+        return resolved
+
     def _get_file_path(self, file_id: str) -> Path:
         """Get the filesystem path for a file ID."""
-        return Path(self.config.storage_dir) / file_id
+        self._validate_file_id(file_id)
+        path = Path(self.config.storage_dir) / file_id
+        return self._validate_path_containment(path)
 
     async def _lookup_file_id(self, file_id: str, action: Action = Action.READ) -> tuple[OpenAIFileObject, Path]:
         """Look up a OpenAIFileObject and filesystem path from its ID."""
+        self._validate_file_id(file_id)
+
         if not self.sql_store:
             raise RuntimeError("Files provider not initialized")
 
@@ -85,6 +133,7 @@ class LocalfsFilesImpl(Files):
             raise OpenAIFileObjectNotFoundError(file_id)
 
         file_path = Path(row.pop("file_path"))
+        file_path = self._validate_path_containment(file_path)
         return OpenAIFileObject(**row), file_path
 
     # OpenAI Files API Implementation
@@ -224,5 +273,7 @@ class LocalfsFilesImpl(Files):
         return Response(
             content=file_path.read_bytes(),
             media_type="application/octet-stream",
-            headers={"Content-Disposition": f'attachment; filename="{file_obj.filename}"'},
+            headers={
+                "Content-Disposition": f'attachment; filename="{sanitize_content_disposition_filename(file_obj.filename)}"'
+            },
         )

--- a/src/llama_stack/providers/remote/files/openai/files.py
+++ b/src/llama_stack/providers/remote/files/openai/files.py
@@ -143,7 +143,7 @@ class OpenAIFilesImpl(Files):
         purpose = request.purpose
         expires_after = request.expires_after
 
-        filename = getattr(file, "filename", None) or "uploaded_file"
+        filename = sanitize_content_disposition_filename(getattr(file, "filename", None) or "uploaded_file")
         content = await file.read()
         file_size = len(content)
 

--- a/src/llama_stack/providers/remote/files/openai/files.py
+++ b/src/llama_stack/providers/remote/files/openai/files.py
@@ -13,6 +13,7 @@ from llama_stack.core.access_control.datatypes import Action
 from llama_stack.core.datatypes import AccessRule
 from llama_stack.core.storage.sqlstore.authorized_sqlstore import AuthorizedSqlStore
 from llama_stack.core.storage.sqlstore.sqlstore import sqlstore_impl
+from llama_stack.providers.utils.files.sanitize import sanitize_content_disposition_filename
 from llama_stack_api import (
     DeleteFileRequest,
     ExpiresAfter,
@@ -249,5 +250,7 @@ class OpenAIFilesImpl(Files):
         return Response(
             content=file_content,
             media_type="application/octet-stream",
-            headers={"Content-Disposition": f'attachment; filename="{row["filename"]}"'},
+            headers={
+                "Content-Disposition": f'attachment; filename="{sanitize_content_disposition_filename(row["filename"])}"'
+            },
         )

--- a/src/llama_stack/providers/remote/files/s3/files.py
+++ b/src/llama_stack/providers/remote/files/s3/files.py
@@ -219,7 +219,7 @@ class S3FilesImpl(Files):
 
         file_id = generate_object_id("file", lambda: f"file-{uuid.uuid4().hex}")
 
-        filename = getattr(file, "filename", None) or "uploaded_file"
+        filename = sanitize_content_disposition_filename(getattr(file, "filename", None) or "uploaded_file")
 
         created_at = self._now()
 

--- a/src/llama_stack/providers/remote/files/s3/files.py
+++ b/src/llama_stack/providers/remote/files/s3/files.py
@@ -20,6 +20,7 @@ from llama_stack.core.datatypes import AccessRule
 from llama_stack.core.id_generation import generate_object_id
 from llama_stack.core.storage.sqlstore.authorized_sqlstore import AuthorizedSqlStore
 from llama_stack.core.storage.sqlstore.sqlstore import sqlstore_impl
+from llama_stack.providers.utils.files.sanitize import sanitize_content_disposition_filename
 from llama_stack_api import (
     ExpiresAfter,
     Files,
@@ -331,5 +332,7 @@ class S3FilesImpl(Files):
         return Response(
             content=content,
             media_type="application/octet-stream",
-            headers={"Content-Disposition": f'attachment; filename="{row["filename"]}"'},
+            headers={
+                "Content-Disposition": f'attachment; filename="{sanitize_content_disposition_filename(row["filename"])}"'
+            },
         )

--- a/src/llama_stack/providers/utils/files/sanitize.py
+++ b/src/llama_stack/providers/utils/files/sanitize.py
@@ -10,7 +10,11 @@ _SAFE_FILENAME_PATTERN = re.compile(r"[^a-zA-Z0-9._-]")
 
 
 def sanitize_content_disposition_filename(filename: str) -> str:
-    """Sanitize *filename* for safe inclusion in a ``Content-Disposition`` header.
+    """Sanitize *filename* for safe storage and inclusion in HTTP headers.
+
+    Applied at **upload time** so the clean value is persisted in the database
+    and returned in API responses, as well as at **download time** in the
+    ``Content-Disposition`` header.
 
     The function strips null bytes and path separators, collapses ``..``
     sequences, prevents hidden-file names (leading dot), and replaces any

--- a/src/llama_stack/providers/utils/files/sanitize.py
+++ b/src/llama_stack/providers/utils/files/sanitize.py
@@ -1,0 +1,27 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import re
+
+_SAFE_FILENAME_PATTERN = re.compile(r"[^a-zA-Z0-9._-]")
+
+
+def sanitize_content_disposition_filename(filename: str) -> str:
+    """Sanitize *filename* for safe inclusion in a ``Content-Disposition`` header.
+
+    The function strips null bytes and path separators, collapses ``..``
+    sequences, prevents hidden-file names (leading dot), and replaces any
+    remaining characters outside an ASCII alphanumeric allowlist.  Returns
+    ``"download"`` when the result would otherwise be empty.
+    """
+    filename = filename.replace("\x00", "")
+    filename = filename.replace('"', "_")  # prevent Content-Disposition header injection
+    filename = filename.replace("/", "_").replace("\\", "_")
+    filename = filename.replace("..", "_")
+    if filename.startswith("."):
+        filename = "_" + filename[1:]
+    filename = _SAFE_FILENAME_PATTERN.sub("_", filename)
+    return filename or "download"

--- a/tests/integration/responses/test_conversation_responses.py
+++ b/tests/integration/responses/test_conversation_responses.py
@@ -94,12 +94,12 @@ class TestConversationResponses:
             )
         assert any(word in str(exc_info.value).lower() for word in ["conv", "invalid", "bad"])
 
-        # Nonexistent conversation ID
+        # Nonexistent conversation ID (must be valid format to reach the DB lookup)
         with pytest.raises(Exception) as exc_info:
             openai_client.responses.create(
                 model=text_model_id,
                 input=[{"role": "user", "content": "Hello"}],
-                conversation="conv_nonexistent123",
+                conversation="conv_" + "0" * 48,
             )
         assert any(word in str(exc_info.value).lower() for word in ["not found", "404"])
 

--- a/tests/integration/responses/test_responses_errors.py
+++ b/tests/integration/responses/test_responses_errors.py
@@ -250,7 +250,7 @@ class TestConversationsAPIErrors:
         Test that referencing a nonexistent conversation returns 404 and triggers
         openai.NotFoundError in the SDK.
         """
-        conversation_id = "conv_nonexistent123456"
+        conversation_id = "conv_" + "0" * 48
         with pytest.raises(NotFoundError) as exc_info:
             openai_client.responses.create(
                 model=text_model_id,

--- a/tests/unit/conversations/test_conversations.py
+++ b/tests/unit/conversations/test_conversations.py
@@ -108,31 +108,32 @@ async def test_conversation_items(service):
 
 
 async def test_invalid_conversation_id(service):
-    with pytest.raises(InvalidParameterError, match="Conversation ID must begin with 'conv_'"):
+    with pytest.raises(InvalidParameterError, match="Conversation ID must match format"):
         await service.get_conversation(GetConversationRequest(conversation_id="invalid_id"))
 
 
 async def test_invalid_conversation_id_on_retrieve(service):
-    with pytest.raises(InvalidParameterError, match="Conversation ID must begin with 'conv_'"):
+    with pytest.raises(InvalidParameterError, match="Conversation ID must match format"):
         await service.retrieve(RetrieveItemRequest(conversation_id="bad_id", item_id="item_123"))
 
 
 async def test_invalid_conversation_id_on_update(service):
     from llama_stack_api.conversations import UpdateConversationRequest
 
-    with pytest.raises(InvalidParameterError, match="Conversation ID must begin with 'conv_'"):
+    with pytest.raises(InvalidParameterError, match="Conversation ID must match format"):
         await service.update_conversation("bad_id", UpdateConversationRequest(metadata={}))
 
 
 async def test_invalid_conversation_id_on_delete(service):
-    with pytest.raises(InvalidParameterError, match="Conversation ID must begin with 'conv_'"):
+    with pytest.raises(InvalidParameterError, match="Conversation ID must match format"):
         await service.openai_delete_conversation(DeleteConversationRequest(conversation_id="bad_id"))
 
 
 async def test_nonexistent_conversation_raises_conversation_not_found(service):
     """Test that get_conversation raises ConversationNotFoundError for nonexistent ID."""
-    with pytest.raises(ConversationNotFoundError, match="Conversation 'conv_nonexistent' not found"):
-        await service.get_conversation(GetConversationRequest(conversation_id="conv_nonexistent"))
+    nonexistent_id = "conv_" + "0" * 48
+    with pytest.raises(ConversationNotFoundError, match=f"Conversation '{nonexistent_id}' not found"):
+        await service.get_conversation(GetConversationRequest(conversation_id=nonexistent_id))
 
 
 async def test_retrieve_nonexistent_item_raises_conversation_item_not_found(service):

--- a/tests/unit/files/test_files.py
+++ b/tests/unit/files/test_files.py
@@ -217,7 +217,7 @@ class TestOpenAIFilesAPI:
     async def test_retrieve_file_not_found(self, files_provider):
         """Test retrieving a non-existent file."""
         with pytest.raises(ResourceNotFoundError, match="not found"):
-            await files_provider.openai_retrieve_file(request=RetrieveFileRequest(file_id="file-nonexistent"))
+            await files_provider.openai_retrieve_file(request=RetrieveFileRequest(file_id="file-" + "0" * 32))
 
     async def test_retrieve_file_content_success(self, files_provider, sample_text_file):
         """Test successful file content retrieval."""
@@ -238,7 +238,7 @@ class TestOpenAIFilesAPI:
         """Test retrieving content of a non-existent file."""
         with pytest.raises(ResourceNotFoundError, match="not found"):
             await files_provider.openai_retrieve_file_content(
-                request=RetrieveFileContentRequest(file_id="file-nonexistent")
+                request=RetrieveFileContentRequest(file_id="file-" + "0" * 32)
             )
 
     async def test_delete_file_success(self, files_provider, sample_text_file):
@@ -265,7 +265,7 @@ class TestOpenAIFilesAPI:
     async def test_delete_file_not_found(self, files_provider):
         """Test deleting a non-existent file."""
         with pytest.raises(ResourceNotFoundError, match="not found"):
-            await files_provider.openai_delete_file(request=DeleteFileRequest(file_id="file-nonexistent"))
+            await files_provider.openai_delete_file(request=DeleteFileRequest(file_id="file-" + "0" * 32))
 
     async def test_file_persistence_across_operations(self, files_provider, sample_text_file):
         """Test that files persist correctly across multiple operations."""

--- a/tests/unit/files/test_path_security.py
+++ b/tests/unit/files/test_path_security.py
@@ -1,0 +1,290 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Security tests for path traversal, file ID validation, Content-Disposition
+sanitization, and conversation ID format enforcement."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from llama_stack.core.access_control.access_control import default_policy
+from llama_stack.core.conversations.conversations import (
+    ConversationServiceConfig,
+    ConversationServiceImpl,
+)
+from llama_stack.core.datatypes import StackConfig
+from llama_stack.core.storage.datatypes import (
+    ServerStoresConfig,
+    SqliteSqlStoreConfig,
+    SqlStoreReference,
+    StorageConfig,
+)
+from llama_stack.core.storage.sqlstore.sqlstore import register_sqlstore_backends
+from llama_stack.providers.inline.files.localfs import (
+    LocalfsFilesImpl,
+    LocalfsFilesImplConfig,
+)
+from llama_stack.providers.utils.files.sanitize import (
+    sanitize_content_disposition_filename,
+)
+from llama_stack_api import InvalidParameterError, OpenAIFilePurpose
+from llama_stack_api.conversations import AddItemsRequest
+from llama_stack_api.files.models import (
+    RetrieveFileContentRequest,
+    UploadFileRequest,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class MockUploadFile:
+    def __init__(self, content: bytes, filename: str):
+        self.content = content
+        self.filename = filename
+
+    async def read(self):
+        return self.content
+
+
+@pytest.fixture
+async def files_provider(tmp_path):
+    storage_dir = tmp_path / "files"
+    db_path = tmp_path / "files_metadata.db"
+
+    backend_name = "sql_security_test"
+    register_sqlstore_backends({backend_name: SqliteSqlStoreConfig(db_path=db_path.as_posix())})
+    config = LocalfsFilesImplConfig(
+        storage_dir=storage_dir.as_posix(),
+        metadata_store=SqlStoreReference(backend=backend_name, table_name="files_metadata"),
+    )
+
+    provider = LocalfsFilesImpl(config, default_policy())
+    await provider.initialize()
+    yield provider
+
+
+@pytest.fixture
+async def conversation_service():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test_sec.db"
+        storage = StorageConfig(
+            backends={"sql_sec": SqliteSqlStoreConfig(db_path=str(db_path))},
+            stores=ServerStoresConfig(
+                conversations=SqlStoreReference(backend="sql_sec", table_name="conversations"),
+                metadata=None,
+                inference=None,
+                prompts=None,
+            ),
+        )
+        register_sqlstore_backends({"sql_sec": storage.backends["sql_sec"]})
+        stack_config = StackConfig(distro_name="test", apis=[], providers={}, storage=storage)
+        config = ConversationServiceConfig(config=stack_config, policy=[])
+        svc = ConversationServiceImpl(config, {})
+        await svc.initialize()
+        yield svc
+
+
+# ---------------------------------------------------------------------------
+# TestFileIdValidation
+# ---------------------------------------------------------------------------
+
+
+class TestFileIdValidation:
+    """Verify that _validate_file_id rejects malformed identifiers."""
+
+    @pytest.mark.parametrize(
+        "good_id",
+        [
+            "file-" + "a" * 32,
+            "file-" + "0" * 32,
+            "file-1",
+            "file-843528265869",
+            "file-" + "f" * 64,
+        ],
+    )
+    def test_valid_file_ids_accepted(self, files_provider, good_id):
+        files_provider._validate_file_id(good_id)
+
+    @pytest.mark.parametrize(
+        "bad_id",
+        [
+            "../etc/passwd",
+            "file-../../etc/passwd",
+            "file-" + "A" * 32,
+            "file-" + "g" * 32,
+            "file-" + "a" * 65,
+            "/etc/passwd",
+            "file-\x00" + "a" * 31,
+            "file-aa/../../etc/passwd",
+            "file-",
+            "",
+            "not-a-file-id",
+        ],
+    )
+    def test_malicious_file_ids_rejected(self, files_provider, bad_id):
+        with pytest.raises(InvalidParameterError):
+            files_provider._validate_file_id(bad_id)
+
+
+# ---------------------------------------------------------------------------
+# TestPathContainment
+# ---------------------------------------------------------------------------
+
+
+class TestPathContainment:
+    """Verify that _validate_path_containment blocks escapes from storage_dir."""
+
+    def test_valid_path_accepted(self, files_provider, tmp_path):
+        storage_dir = Path(files_provider.config.storage_dir)
+        valid = storage_dir / ("file-" + "a" * 32)
+        result = files_provider._validate_path_containment(valid)
+        assert result.is_relative_to(storage_dir.resolve())
+
+    def test_traversal_via_dotdot_rejected(self, files_provider):
+        storage_dir = Path(files_provider.config.storage_dir)
+        malicious = storage_dir / ".." / "etc" / "passwd"
+        with pytest.raises(InvalidParameterError):
+            files_provider._validate_path_containment(malicious)
+
+    def test_absolute_path_outside_storage_rejected(self, files_provider):
+        with pytest.raises(InvalidParameterError):
+            files_provider._validate_path_containment(Path("/etc/passwd"))
+
+    def test_symlink_escape_rejected(self, files_provider, tmp_path):
+        storage_dir = Path(files_provider.config.storage_dir)
+        outside_file = tmp_path / "outside_secret.txt"
+        outside_file.write_text("secret")
+        symlink = storage_dir / "sneaky_link"
+        symlink.symlink_to(outside_file)
+
+        with pytest.raises(InvalidParameterError):
+            files_provider._validate_path_containment(symlink)
+
+    async def test_poisoned_db_path_rejected(self, files_provider):
+        """Simulate a compromised DB row with a traversal path."""
+        provider = files_provider
+        assert provider.sql_store is not None
+
+        file_id = provider._generate_file_id()
+        poisoned_path = Path(provider.config.storage_dir) / ".." / "etc" / "passwd"
+
+        await provider.sql_store.insert(
+            "openai_files",
+            {
+                "id": file_id,
+                "filename": "innocent.txt",
+                "purpose": "assistants",
+                "bytes": 10,
+                "created_at": 1,
+                "expires_at": 99999999999,
+                "file_path": poisoned_path.as_posix(),
+            },
+        )
+
+        with pytest.raises(InvalidParameterError):
+            await provider._lookup_file_id(file_id)
+
+
+# ---------------------------------------------------------------------------
+# TestContentDispositionSanitization
+# ---------------------------------------------------------------------------
+
+
+class TestContentDispositionSanitization:
+    """Verify filename sanitization for Content-Disposition headers."""
+
+    def test_normal_filename_unchanged(self):
+        assert sanitize_content_disposition_filename("report.pdf") == "report.pdf"
+
+    def test_traversal_sequences_removed(self):
+        result = sanitize_content_disposition_filename("../../etc/passwd")
+        assert "/" not in result
+        assert ".." not in result
+
+    def test_null_bytes_stripped(self):
+        result = sanitize_content_disposition_filename("file\x00name.txt")
+        assert "\x00" not in result
+
+    def test_hidden_file_gets_prefix(self):
+        result = sanitize_content_disposition_filename(".htaccess")
+        assert not result.startswith(".")
+
+    def test_empty_filename_returns_download(self):
+        assert sanitize_content_disposition_filename("") == "download"
+
+    def test_backslashes_replaced(self):
+        result = sanitize_content_disposition_filename("dir\\file.txt")
+        assert "\\" not in result
+
+    def test_slashes_replaced(self):
+        result = sanitize_content_disposition_filename("dir/file.txt")
+        assert "/" not in result
+
+    async def test_content_disposition_header_uses_sanitized_name(self, files_provider):
+        """End-to-end: upload a file with a nasty name, retrieve it, check the header."""
+        nasty_name = "../../etc/passwd"
+        upload = MockUploadFile(b"test content", nasty_name)
+
+        uploaded = await files_provider.openai_upload_file(
+            request=UploadFileRequest(purpose=OpenAIFilePurpose.ASSISTANTS),
+            file=upload,
+        )
+
+        response = await files_provider.openai_retrieve_file_content(
+            request=RetrieveFileContentRequest(file_id=uploaded.id),
+        )
+
+        header = response.headers["content-disposition"]
+        assert ".." not in header
+        assert "/" not in header
+
+
+# ---------------------------------------------------------------------------
+# TestConversationIdValidation
+# ---------------------------------------------------------------------------
+
+
+class TestConversationIdValidation:
+    """Verify conversation ID regex enforcement."""
+
+    VALID_CONV_ID = "conv_" + "a" * 48
+
+    def test_valid_conversation_id_accepted(self, conversation_service):
+        conversation_service._validate_conversation_id(self.VALID_CONV_ID)
+
+    @pytest.mark.parametrize(
+        "bad_id",
+        [
+            "conv_" + "a" * 47,
+            "conv_" + "a" * 49,
+            "conv_" + "G" * 48,
+            "conv_../../etc/passwd" + "a" * 30,
+            "../../../etc/passwd",
+            "",
+            "not_a_conv_id",
+            "conv_" + "\x00" + "a" * 47,
+        ],
+    )
+    def test_malicious_conversation_ids_rejected(self, conversation_service, bad_id):
+        with pytest.raises(InvalidParameterError):
+            conversation_service._validate_conversation_id(bad_id)
+
+    async def test_add_items_rejects_bad_conversation_id(self, conversation_service):
+        """_get_validated_conversation calls _validate_conversation_id."""
+        bad_id = "../../../etc/shadow"
+        with pytest.raises(InvalidParameterError):
+            await conversation_service.add_items(
+                bad_id,
+                AddItemsRequest(
+                    items=[
+                        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hello"}]},
+                    ]
+                ),
+            )

--- a/tests/unit/files/test_path_security.py
+++ b/tests/unit/files/test_path_security.py
@@ -227,10 +227,23 @@ class TestContentDispositionSanitization:
         result = sanitize_content_disposition_filename("dir/file.txt")
         assert "/" not in result
 
+    async def test_upload_sanitizes_stored_filename(self, files_provider):
+        """The returned OpenAIFileObject should already contain the sanitized name."""
+        malicious_name = "../../etc/passwd"
+        upload = MockUploadFile(b"test content", malicious_name)
+
+        uploaded = await files_provider.openai_upload_file(
+            request=UploadFileRequest(purpose=OpenAIFilePurpose.ASSISTANTS),
+            file=upload,
+        )
+
+        assert ".." not in uploaded.filename
+        assert "/" not in uploaded.filename
+
     async def test_content_disposition_header_uses_sanitized_name(self, files_provider):
-        """End-to-end: upload a file with a nasty name, retrieve it, check the header."""
-        nasty_name = "../../etc/passwd"
-        upload = MockUploadFile(b"test content", nasty_name)
+        """End-to-end: upload a file with a malicious name, retrieve it, check the header."""
+        malicious_name = "../../etc/passwd"
+        upload = MockUploadFile(b"test content", malicious_name)
 
         uploaded = await files_provider.openai_upload_file(
             request=UploadFileRequest(purpose=OpenAIFilePurpose.ASSISTANTS),

--- a/tests/unit/providers/agents/meta_reference/test_openai_responses_conversations.py
+++ b/tests/unit/providers/agents/meta_reference/test_openai_responses_conversations.py
@@ -224,7 +224,9 @@ class TestIntegrationWorkflow:
 
     async def test_create_response_with_invalid_conversation_id(self, responses_impl_with_conversations):
         """Test creating a response with an invalid conversation ID."""
-        with pytest.raises(InvalidParameterError, match="Must match format 'conv_' followed by 48 hex characters"):
+        with pytest.raises(
+            InvalidParameterError, match="Must match format 'conv_' followed by 48 lowercase hex characters"
+        ):
             await responses_impl_with_conversations.create_openai_response(
                 input="Hello", model="test-model", conversation="invalid_id", stream=False
             )

--- a/tests/unit/providers/agents/meta_reference/test_openai_responses_conversations.py
+++ b/tests/unit/providers/agents/meta_reference/test_openai_responses_conversations.py
@@ -62,10 +62,10 @@ class TestConversationValidation:
         self, responses_impl_with_conversations, mock_conversations_api
     ):
         """Test that ConversationNotFoundError is raised for non-existent conversation."""
-        conv_id = "conv_nonexistent"
+        conv_id = "conv_" + "0" * 48
 
         # Mock conversation not found
-        mock_conversations_api.list_items.side_effect = ConversationNotFoundError("conv_nonexistent")
+        mock_conversations_api.list_items.side_effect = ConversationNotFoundError(conv_id)
 
         with pytest.raises(ConversationNotFoundError):
             await responses_impl_with_conversations.create_openai_response(
@@ -209,7 +209,7 @@ class TestIntegrationWorkflow:
         responses_impl_with_conversations._create_streaming_response = mock_streaming_response
 
         input_text = "Hello, how are you?"
-        conversation_id = "conv_test123"
+        conversation_id = "conv_" + "a" * 48
 
         response = await responses_impl_with_conversations.create_openai_response(
             input=input_text, model="test-model", conversation=conversation_id, stream=False
@@ -224,7 +224,7 @@ class TestIntegrationWorkflow:
 
     async def test_create_response_with_invalid_conversation_id(self, responses_impl_with_conversations):
         """Test creating a response with an invalid conversation ID."""
-        with pytest.raises(InvalidParameterError, match="Expected an ID that begins with 'conv_'"):
+        with pytest.raises(InvalidParameterError, match="Must match format 'conv_' followed by 48 hex characters"):
             await responses_impl_with_conversations.create_openai_response(
                 input="Hello", model="test-model", conversation="invalid_id", stream=False
             )
@@ -233,11 +233,12 @@ class TestIntegrationWorkflow:
         self, responses_impl_with_conversations, mock_conversations_api
     ):
         """Test creating a response with a non-existent conversation."""
-        mock_conversations_api.list_items.side_effect = ConversationNotFoundError("conv_nonexistent")
+        conv_id = "conv_" + "b" * 48
+        mock_conversations_api.list_items.side_effect = ConversationNotFoundError(conv_id)
 
         with pytest.raises(ConversationNotFoundError) as exc_info:
             await responses_impl_with_conversations.create_openai_response(
-                input="Hello", model="test-model", conversation="conv_nonexistent", stream=False
+                input="Hello", model="test-model", conversation=conv_id, stream=False
             )
 
         assert "not found" in str(exc_info.value)


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->
- Add defense-in-depth path sanitization to the localfs files provider to
  prevent path traversal attacks, even in the event of a compromised metadata
  database.
- Validate `file_id` against `^file-[0-9a-f]{32}$` and `conversation_id`
  against `^conv_[0-9a-f]{48}$` before use.
- Canonicalize all file paths with `Path.resolve()` and enforce containment
  within `storage_dir` via `is_relative_to()`.
- Sanitize `Content-Disposition` filenames in all three file providers (localfs,
  openai, s3) to strip path separators, `..` sequences, null bytes, and
  non-safe characters.
- Add 35 security-focused unit tests and update existing tests to use
  properly-formatted IDs.


<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->
Closes RHAIENG-1866

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->
- [x] `pytest tests/unit/files/test_path_security.py` -- 35 new security tests
  (file ID validation, path containment, symlink escape, poisoned DB row,
  Content-Disposition sanitization, conversation ID validation)
- [x] `pytest tests/unit/files/test_files.py` -- existing file tests pass with
  updated valid-format IDs
- [x] `pytest tests/unit/conversations/test_conversations.py` -- updated error
  message assertion passes
- [x] `pytest tests/unit/providers/agents/meta_reference/test_openai_responses_conversations.py`
  -- updated conversation ID formats pass
- [x] All 93 affected unit tests pass

<!-- For API changes, include:
1. A testing script (Python, curl, etc.) that exercises the new/modified endpoints
2. The output from running your script

Example:
```python
...
...
```

Output:
```
<paste actual output here>
```
-->
