### PR TITLE
feat(security): strict TLS mode

### DIFF
--- a/src/llama_stack/cli/stack/run.py
+++ b/src/llama_stack/cli/stack/run.py
@@ -66,6 +66,19 @@ class StackRun(Subcommand):
             default=None,
             help="Run a stack with only a list of providers. This list is formatted like: api1=provider1,api1=provider2,api2=provider3. Where there can be multiple providers per API.",
         )
+        self.parser.add_argument(
+            "--security-mode",
+            type=str,
+            choices=["development", "production"],
+            default=None,
+            help="Override the security mode from config. 'production' requires TLS certificates.",
+        )
+        self.parser.add_argument(
+            "--insecure",
+            action="store_true",
+            default=False,
+            help="Force development security mode (allows HTTP without TLS). Overrides --security-mode and config.",
+        )
 
     def _run_stack_run_cmd(self, args: argparse.Namespace) -> None:
         import yaml
@@ -129,7 +142,19 @@ class StackRun(Subcommand):
         config_file = resolve_config_or_distro(str(config_file))
         with open(config_file) as fp:
             config_contents = yaml.safe_load(fp)
-            config = StackConfig(**cast_distro_name_to_string(replace_env_vars(config_contents)))
+            config_contents = cast_distro_name_to_string(replace_env_vars(config_contents))
+
+            # Apply CLI security mode overrides BEFORE model validation,
+            # so --insecure can downgrade production mode without triggering the validator.
+            if args.insecure or args.security_mode:
+                if "server" not in config_contents:
+                    config_contents["server"] = {}
+                if args.insecure:
+                    config_contents["server"]["security_mode"] = "development"
+                elif args.security_mode:
+                    config_contents["server"]["security_mode"] = args.security_mode
+
+            config = StackConfig(**config_contents)
 
         port = args.port or config.server.port
         workers = config.server.workers
@@ -165,11 +190,17 @@ class StackRun(Subcommand):
                 uvicorn_config["ssl_ca_certs"] = config.server.tls_cafile
                 uvicorn_config["ssl_cert_reqs"] = ssl.CERT_REQUIRED
 
+            if config.server.tls_config and config.server.tls_config.ciphers:
+                uvicorn_config["ssl_ciphers"] = ":".join(config.server.tls_config.ciphers)
+
             logger.info(
                 "HTTPS enabled with certificates", keyfile=keyfile, certfile=certfile, cafile=config.server.tls_cafile
             )
         else:
-            logger.info("HTTPS enabled with certificates", keyfile=keyfile, certfile=certfile)
+            logger.warning(
+                "TLS is not enabled — server will transmit data in cleartext. "
+                "Set tls_certfile and tls_keyfile in server config to enable HTTPS."
+            )
 
         logger.info("Listening on", host=host, port=port)
 

--- a/src/llama_stack/core/datatypes.py
+++ b/src/llama_stack/core/datatypes.py
@@ -755,6 +755,9 @@ class RegisteredResources(BaseModel):
         return self
 
 
+from llama_stack.core.server_tls import FIPS_APPROVED_CIPHERS, SecurityMode, ServerTLSConfig  # noqa: E402
+
+
 class ServerConfig(BaseModel):
     """Configuration for the HTTP(S) server including TLS, authentication, and quotas."""
 
@@ -803,6 +806,33 @@ class ServerConfig(BaseModel):
         description="Interval in seconds between registry refreshes for syncing model information from providers",
         gt=0,
     )
+    security_mode: SecurityMode = Field(
+        default=SecurityMode.DEVELOPMENT,
+        description="Security mode: 'development' (allows HTTP, warnings only) or 'production' (requires TLS with FIPS-approved ciphers)",
+    )
+    tls_config: ServerTLSConfig | None = Field(
+        default=None,
+        description="TLS configuration (cipher suites). Auto-populated with FIPS defaults in production mode.",
+    )
+    hsts_max_age: int = Field(
+        default=31536000,
+        description="HSTS Strict-Transport-Security max-age in seconds. Only applied when TLS is enabled. Set to 0 to disable HSTS.",
+        ge=0,
+    )
+
+    @model_validator(mode="after")
+    def validate_security_mode(self) -> "ServerConfig":
+        if self.security_mode == SecurityMode.PRODUCTION:
+            if not self.tls_certfile or not self.tls_keyfile:
+                raise ValueError(
+                    "Production security mode requires TLS: set 'tls_certfile' and 'tls_keyfile' in server config, "
+                    "or use '--insecure' / security_mode='development' to run without TLS."
+                )
+            if self.tls_config is None:
+                self.tls_config = ServerTLSConfig(ciphers=FIPS_APPROVED_CIPHERS)
+            elif self.tls_config.ciphers is None:
+                self.tls_config.ciphers = FIPS_APPROVED_CIPHERS
+        return self
 
 
 class StackConfig(BaseModel):

--- a/src/llama_stack/core/server/auth_providers.py
+++ b/src/llama_stack/core/server/auth_providers.py
@@ -28,6 +28,20 @@ from llama_stack_api import TokenValidationError
 
 logger = get_logger(name=__name__, category="core::auth")
 
+# FIPS-approved JWT signing algorithms (asymmetric only).
+# Symmetric algorithms (HS256, etc.) are excluded to prevent algorithm confusion attacks.
+FIPS_APPROVED_JWT_ALGORITHMS = [
+    "RS256",
+    "RS384",
+    "RS512",
+    "PS256",
+    "PS384",
+    "PS512",
+    "ES256",
+    "ES384",
+    "ES512",
+]
+
 
 class AuthResponse(BaseModel):
     """The format of the authentication response from the auth endpoint."""
@@ -190,13 +204,13 @@ class OAuth2TokenAuthProvider(AuthProvider):
         try:
             jwks_client: jwt.PyJWKClient = self._get_jwks_client()
             signing_key = jwks_client.get_signing_key_from_jwt(token)
-            algorithm = jwt.get_unverified_header(token)["alg"]
 
-            # Decode and verify the JWT
+            # Decode and verify the JWT using a static allowlist of FIPS-approved algorithms.
+            # Never trust the algorithm from the unverified token header (algorithm confusion attack).
             claims = jwt.decode(
                 token,
                 signing_key.key,
-                algorithms=[algorithm],
+                algorithms=FIPS_APPROVED_JWT_ALGORITHMS,
                 audience=self.config.audience,
                 issuer=self.config.issuer,
                 options={"verify_exp": True, "verify_aud": True, "verify_iss": True},
@@ -221,9 +235,11 @@ class OAuth2TokenAuthProvider(AuthProvider):
         if self.config.introspection is None:
             raise ValueError("Introspection is not configured")
 
-        # ssl_ctxt can be None, bool, str, or SSLContext - httpx accepts all
-        ssl_ctxt: ssl.SSLContext | bool = False  # Default to no verification if no cafile
-        if self.config.tls_cafile:
+        # Default to True (system CA verification); only disable when verify_tls=False
+        ssl_ctxt: ssl.SSLContext | bool = True
+        if not self.config.verify_tls:
+            ssl_ctxt = False
+        elif self.config.tls_cafile:
             ssl_ctxt = ssl.create_default_context(cafile=self.config.tls_cafile.as_posix())
 
         # Build post kwargs conditionally based on auth method

--- a/src/llama_stack/core/server/server.py
+++ b/src/llama_stack/core/server/server.py
@@ -29,6 +29,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 from llama_stack.core.access_control.access_control import AccessDeniedError
 from llama_stack.core.datatypes import (
     AuthenticationRequiredError,
+    SecurityMode,
     StackConfig,
     process_cors_config,
 )
@@ -155,6 +156,27 @@ async def _send_error_response(send: Send, status: int, message: str) -> None:
     await send({"type": "http.response.body", "body": error_msg})
 
 
+class HSTSMiddleware:
+    """Adds Strict-Transport-Security header to all HTTPS responses."""
+
+    def __init__(self, app: ASGIApp, max_age: int = 31536000) -> None:
+        self.app = app
+        self.hsts_value = f"max-age={max_age}; includeSubDomains".encode()
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> Any:
+        if scope["type"] == "http":
+
+            async def send_with_hsts(message: dict[str, Any]) -> None:
+                if message["type"] == "http.response.start":
+                    headers = list(message.get("headers", []))
+                    headers.append([b"strict-transport-security", self.hsts_value])
+                    message["headers"] = headers
+                await send(message)
+
+            return await self.app(scope, receive, send_with_hsts)
+        return await self.app(scope, receive, send)
+
+
 class ClientVersionMiddleware:
     """ASGI middleware that rejects requests from clients with incompatible major.minor versions."""
 
@@ -263,6 +285,10 @@ def create_app() -> StackApp:
         config=config,
     )
 
+    # Add HSTS middleware when TLS is configured and HSTS is not disabled
+    if config.server.tls_certfile and config.server.tls_keyfile and config.server.hsts_max_age > 0:
+        app.add_middleware(HSTSMiddleware, max_age=config.server.hsts_max_age)
+
     if not os.environ.get("LLAMA_STACK_DISABLE_VERSION_CHECK"):
         app.add_middleware(ClientVersionMiddleware)
 
@@ -270,6 +296,21 @@ def create_app() -> StackApp:
 
     impls = app.stack.impls
     assert impls is not None
+
+    # Enforce or warn about verify_tls=False in auth config based on security mode
+    if config.server.auth:
+        provider_config = config.server.auth.provider_config
+        if provider_config and hasattr(provider_config, "verify_tls") and not provider_config.verify_tls:
+            if config.server.security_mode == SecurityMode.PRODUCTION:
+                raise SystemExit(
+                    "FATAL: Production security mode forbids verify_tls=False in auth provider config. "
+                    "TLS verification must be enabled for production deployments."
+                )
+            else:
+                logger.warning(
+                    "TLS verification is disabled in auth provider config (verify_tls=False). "
+                    "This is insecure and should only be used for local development or testing."
+                )
 
     if config.server.auth:
         # Add route authorization middleware if route_policy is configured

--- a/src/llama_stack/core/server_tls.py
+++ b/src/llama_stack/core/server_tls.py
@@ -1,0 +1,37 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+
+class SecurityMode(StrEnum):
+    """Server security mode controlling TLS enforcement."""
+
+    DEVELOPMENT = "development"
+    PRODUCTION = "production"
+
+
+FIPS_APPROVED_CIPHERS = [
+    "ECDHE-ECDSA-AES128-GCM-SHA256",
+    "ECDHE-RSA-AES128-GCM-SHA256",
+    "ECDHE-ECDSA-AES256-GCM-SHA384",
+    "ECDHE-RSA-AES256-GCM-SHA384",
+    "DHE-RSA-AES128-GCM-SHA256",
+    "DHE-RSA-AES256-GCM-SHA384",
+]
+
+
+class ServerTLSConfig(BaseModel):
+    """TLS cipher suite configuration for the server."""
+
+    # Note: minimum TLS version is not configurable here because uvicorn does not
+    # expose ssl.SSLContext.minimum_version. Python 3.10+ defaults to TLS 1.2 minimum.
+    ciphers: list[str] | None = Field(
+        default=None,
+        description="Allowed TLS 1.2 cipher suites (OpenSSL names). Defaults to FIPS-approved AES-GCM ciphers.",
+    )

--- a/tests/unit/server/test_auth.py
+++ b/tests/unit/server/test_auth.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-import base64
 import json
 import logging  # allow-direct-logging
 from unittest.mock import AsyncMock, Mock, patch
@@ -333,9 +332,42 @@ def test_invalid_auth_header_format_oauth2(oauth2_client):
 
 
 @pytest.fixture
-def jwt_token_valid():
+def rsa_key_pair():
+    """Generate an RSA key pair for JWT signing/verification tests."""
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_key = private_key.public_key()
+    public_numbers = public_key.public_numbers()
+    # Build JWK for mock JWKS endpoint
+    import base64
+
+    def _int_to_base64url(n, length=None):
+        b = n.to_bytes((n.bit_length() + 7) // 8, byteorder="big")
+        return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+
+    jwk = {
+        "kid": "rsa-test-key",
+        "kty": "RSA",
+        "alg": "RS256",
+        "use": "sig",
+        "n": _int_to_base64url(public_numbers.n),
+        "e": _int_to_base64url(public_numbers.e),
+    }
+    return private_pem, jwk
+
+
+@pytest.fixture
+def jwt_token_valid(rsa_key_pair):
     import jwt
 
+    private_pem, _ = rsa_key_pair
     return jwt.encode(
         {
             "sub": "my-user",
@@ -343,46 +375,33 @@ def jwt_token_valid():
             "scope": "foo bar",
             "aud": "llama-stack",
         },
-        key="foobarbaz",
-        algorithm="HS256",
-        headers={"kid": "1234567890"},
+        key=private_pem,
+        algorithm="RS256",
+        headers={"kid": "rsa-test-key"},
     )
 
 
 @pytest.fixture
-def mock_jwks_urlopen():
+def mock_jwks_urlopen(rsa_key_pair):
     """Mock urllib.request.urlopen for PyJWKClient JWKS requests."""
+    _, jwk = rsa_key_pair
     with patch("urllib.request.urlopen") as mock_urlopen:
-        # Mock the JWKS response for PyJWKClient
         mock_response = Mock()
-        mock_response.read.return_value = json.dumps(
-            {
-                "keys": [
-                    {
-                        "kid": "1234567890",
-                        "kty": "oct",
-                        "alg": "HS256",
-                        "use": "sig",
-                        "k": base64.b64encode(b"foobarbaz").decode(),
-                    }
-                ]
-            }
-        ).encode()
+        mock_response.read.return_value = json.dumps({"keys": [jwk]}).encode()
         mock_urlopen.return_value.__enter__.return_value = mock_response
         yield mock_urlopen
 
 
 @pytest.fixture
-def mock_jwks_urlopen_with_auth_required():
+def mock_jwks_urlopen_with_auth_required(rsa_key_pair):
     """Mock urllib.request.urlopen that requires Bearer token for JWKS requests."""
+    _, jwk = rsa_key_pair
     with patch("urllib.request.urlopen") as mock_urlopen:
 
         def side_effect(request, **kwargs):
-            # Check if Authorization header is present
             auth_header = request.headers.get("Authorization") if hasattr(request, "headers") else None
 
             if not auth_header or not auth_header.startswith("Bearer "):
-                # Simulate 401 Unauthorized
                 import urllib.error
 
                 raise urllib.error.HTTPError(
@@ -393,21 +412,8 @@ def mock_jwks_urlopen_with_auth_required():
                     fp=None,
                 )
 
-            # Mock the JWKS response for PyJWKClient
             mock_response = Mock()
-            mock_response.read.return_value = json.dumps(
-                {
-                    "keys": [
-                        {
-                            "kid": "1234567890",
-                            "kty": "oct",
-                            "alg": "HS256",
-                            "use": "sig",
-                            "k": base64.b64encode(b"foobarbaz").decode(),
-                        }
-                    ]
-                }
-            ).encode()
+            mock_response.read.return_value = json.dumps({"keys": [jwk]}).encode()
             return mock_response
 
         mock_urlopen.side_effect = side_effect
@@ -433,7 +439,7 @@ def oauth2_app_with_jwks_token():
         provider_config=OAuth2TokenAuthConfig(
             type=AuthProviderType.OAUTH2_TOKEN,
             jwks=OAuth2JWKSConfig(
-                uri="http://mock-authz-service/token/introspect",
+                uri="http://mock-authz-service/jwks",
                 key_recheck_period=3600,
                 token="my-jwks-token",
             ),
@@ -585,7 +591,47 @@ def test_get_attributes_from_claims():
     assert attributes["region"] == ["us-west"]
 
 
-# TODO: add more tests for oauth2 token provider
+# Tests for introspection SSL defaults and JWT algorithm allowlist
+
+
+def test_introspection_default_uses_system_certs():
+    """Introspection should verify TLS by default (ssl_ctxt=None), not skip it (ssl_ctxt=False)."""
+    from llama_stack.core.server.auth_providers import OAuth2TokenAuthProvider
+
+    config = OAuth2TokenAuthConfig(
+        type=AuthProviderType.OAUTH2_TOKEN,
+        introspection=OAuth2IntrospectionConfig(
+            url="https://auth.example.com/introspect",
+            client_id="myclient",
+            client_secret="mysecret",
+        ),
+        verify_tls=True,
+    )
+    OAuth2TokenAuthProvider(config)
+
+    # The fix ensures ssl_ctxt defaults to None (system CA) instead of False
+    assert config.verify_tls is True
+    assert config.tls_cafile is None
+
+
+@pytest.mark.parametrize("bad_algorithm", ["HS256", "none", "EdDSA"])
+def test_jwt_rejects_non_fips_algorithm(bad_algorithm, suppress_auth_errors):
+    """JWT validation should reject non-FIPS algorithms like HS256, none, and EdDSA."""
+    from llama_stack.core.server.auth_providers import FIPS_APPROVED_JWT_ALGORITHMS
+
+    # Verify these algorithms are NOT in the allowlist
+    assert bad_algorithm not in FIPS_APPROVED_JWT_ALGORITHMS
+
+
+def test_jwt_fips_allowlist_contents():
+    """Verify the FIPS-approved JWT algorithm allowlist contains only expected asymmetric algorithms."""
+    from llama_stack.core.server.auth_providers import FIPS_APPROVED_JWT_ALGORITHMS
+
+    expected = {"RS256", "RS384", "RS512", "PS256", "PS384", "PS512", "ES256", "ES384", "ES512"}
+    assert set(FIPS_APPROVED_JWT_ALGORITHMS) == expected
+    # No symmetric algorithms
+    for alg in FIPS_APPROVED_JWT_ALGORITHMS:
+        assert not alg.startswith("HS"), f"Symmetric algorithm {alg} should not be in FIPS allowlist"
 
 
 # oauth token introspection tests

--- a/tests/unit/server/test_tls_config.py
+++ b/tests/unit/server/test_tls_config.py
@@ -1,0 +1,222 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from llama_stack.core.datatypes import (
+    FIPS_APPROVED_CIPHERS,
+    SecurityMode,
+    ServerConfig,
+    ServerTLSConfig,
+    StackConfig,
+)
+
+
+class TestSecurityModeValidation:
+    def test_development_mode_no_certs_allowed(self):
+        """Development mode should work without TLS certificates."""
+        config = ServerConfig(security_mode=SecurityMode.DEVELOPMENT)
+        assert config.security_mode == SecurityMode.DEVELOPMENT
+        assert config.tls_certfile is None
+        assert config.tls_keyfile is None
+
+    def test_production_mode_requires_certs(self):
+        """Production mode should raise ValueError without TLS certificates."""
+        with pytest.raises(ValueError, match="Production security mode requires TLS"):
+            ServerConfig(security_mode=SecurityMode.PRODUCTION)
+
+    def test_production_mode_requires_both_certs(self):
+        """Production mode should require both cert and key."""
+        with pytest.raises(ValueError, match="Production security mode requires TLS"):
+            ServerConfig(
+                security_mode=SecurityMode.PRODUCTION,
+                tls_certfile="/path/to/cert.pem",
+            )
+
+    def test_production_mode_with_certs(self):
+        """Production mode should succeed with both cert and key."""
+        config = ServerConfig(
+            security_mode=SecurityMode.PRODUCTION,
+            tls_certfile="/path/to/cert.pem",
+            tls_keyfile="/path/to/key.pem",
+        )
+        assert config.security_mode == SecurityMode.PRODUCTION
+
+    def test_production_mode_auto_populates_fips_ciphers(self):
+        """Production mode should auto-populate FIPS-approved cipher suites."""
+        config = ServerConfig(
+            security_mode=SecurityMode.PRODUCTION,
+            tls_certfile="/path/to/cert.pem",
+            tls_keyfile="/path/to/key.pem",
+        )
+        assert config.tls_config is not None
+        assert config.tls_config.ciphers == FIPS_APPROVED_CIPHERS
+
+    def test_production_mode_auto_populates_ciphers_when_tls_config_has_none(self):
+        """Production mode should fill in ciphers when tls_config exists but ciphers is None."""
+        config = ServerConfig(
+            security_mode=SecurityMode.PRODUCTION,
+            tls_certfile="/path/to/cert.pem",
+            tls_keyfile="/path/to/key.pem",
+            tls_config=ServerTLSConfig(),
+        )
+        assert config.tls_config.ciphers == FIPS_APPROVED_CIPHERS
+
+    def test_production_mode_preserves_custom_ciphers(self):
+        """Production mode should not overwrite explicitly set ciphers."""
+        custom_ciphers = ["ECDHE-RSA-AES256-GCM-SHA384"]
+        config = ServerConfig(
+            security_mode=SecurityMode.PRODUCTION,
+            tls_certfile="/path/to/cert.pem",
+            tls_keyfile="/path/to/key.pem",
+            tls_config=ServerTLSConfig(ciphers=custom_ciphers),
+        )
+        assert config.tls_config.ciphers == custom_ciphers
+
+    def test_development_mode_does_not_auto_populate_tls_config(self):
+        """Development mode should not auto-create tls_config."""
+        config = ServerConfig(security_mode=SecurityMode.DEVELOPMENT)
+        assert config.tls_config is None
+
+    def test_default_security_mode_is_development(self):
+        """Default security mode should be development."""
+        config = ServerConfig()
+        assert config.security_mode == SecurityMode.DEVELOPMENT
+
+
+class TestInsecureFlagOverride:
+    def test_insecure_overrides_production_in_raw_config(self):
+        """--insecure should override production mode in YAML before validation."""
+        raw_config = {
+            "version": 2,
+            "distro_name": "test",
+            "providers": {},
+            "server": {"security_mode": "production"},
+        }
+        # Simulate CLI override applied to raw dict before StackConfig construction
+        raw_config["server"]["security_mode"] = "development"
+
+        config = StackConfig(**raw_config)
+        assert config.server.security_mode == SecurityMode.DEVELOPMENT
+
+    def test_production_mode_fails_without_insecure(self):
+        """Without --insecure, production mode without certs should fail at construction."""
+        raw_config = {
+            "version": 2,
+            "distro_name": "test",
+            "providers": {},
+            "server": {"security_mode": "production"},
+        }
+        with pytest.raises(ValueError, match="Production security mode requires TLS"):
+            StackConfig(**raw_config)
+
+
+class TestProductionVerifyTlsFalse:
+    def test_production_mode_rejects_verify_tls_false(self):
+        """Production mode should reject auth configs with verify_tls=False at server startup."""
+        from llama_stack.core.datatypes import (
+            AuthenticationConfig,
+            OAuth2IntrospectionConfig,
+            OAuth2TokenAuthConfig,
+        )
+
+        auth_config = AuthenticationConfig(
+            provider_config=OAuth2TokenAuthConfig(
+                introspection=OAuth2IntrospectionConfig(
+                    url="https://auth.example.com/introspect",
+                    client_id="client",
+                    client_secret="secret",
+                ),
+                verify_tls=False,
+            ),
+        )
+        # The check happens in server.py create_app, not in the model validator.
+        # Here we verify the config can be created (the server will reject it at startup).
+        assert auth_config.provider_config.verify_tls is False
+
+
+class TestHSTSMiddleware:
+    def test_hsts_header_default_max_age(self):
+        """HSTS header should use default max-age of 1 year."""
+        from llama_stack.core.server.server import HSTSMiddleware
+
+        app = FastAPI()
+
+        @app.get("/test")
+        def test_endpoint():
+            return {"status": "ok"}
+
+        app.add_middleware(HSTSMiddleware)
+        client = TestClient(app)
+
+        response = client.get("/test")
+        assert response.status_code == 200
+        assert response.headers["strict-transport-security"] == "max-age=31536000; includeSubDomains"
+
+    def test_hsts_header_custom_max_age(self):
+        """HSTS header should respect custom max-age."""
+        from llama_stack.core.server.server import HSTSMiddleware
+
+        app = FastAPI()
+
+        @app.get("/test")
+        def test_endpoint():
+            return {"status": "ok"}
+
+        app.add_middleware(HSTSMiddleware, max_age=86400)
+        client = TestClient(app)
+
+        response = client.get("/test")
+        assert response.status_code == 200
+        assert response.headers["strict-transport-security"] == "max-age=86400; includeSubDomains"
+
+    def test_hsts_header_absent_without_middleware(self):
+        """HSTS header should not be present when middleware is not added."""
+        app = FastAPI()
+
+        @app.get("/test")
+        def test_endpoint():
+            return {"status": "ok"}
+
+        client = TestClient(app)
+
+        response = client.get("/test")
+        assert response.status_code == 200
+        assert "strict-transport-security" not in response.headers
+
+    def test_hsts_max_age_config_default(self):
+        """ServerConfig hsts_max_age should default to 1 year."""
+        config = ServerConfig()
+        assert config.hsts_max_age == 31536000
+
+    def test_hsts_max_age_config_zero_disables(self):
+        """hsts_max_age=0 should be valid (used to disable HSTS)."""
+        config = ServerConfig(hsts_max_age=0)
+        assert config.hsts_max_age == 0
+
+    def test_hsts_max_age_config_rejects_negative(self):
+        """hsts_max_age must not be negative."""
+        with pytest.raises(ValueError):
+            ServerConfig(hsts_max_age=-1)
+
+
+class TestFIPSCipherConstants:
+    def test_fips_ciphers_are_aes_gcm_only(self):
+        """All FIPS-approved ciphers should be AES-GCM variants."""
+        for cipher in FIPS_APPROVED_CIPHERS:
+            assert "GCM" in cipher, f"Cipher {cipher} is not AES-GCM"
+
+    def test_fips_ciphers_no_chacha(self):
+        """CHACHA20-POLY1305 should not be in FIPS-approved list."""
+        for cipher in FIPS_APPROVED_CIPHERS:
+            assert "CHACHA" not in cipher, f"Cipher {cipher} should not be in FIPS list"
+
+    def test_server_tls_config_defaults(self):
+        """ServerTLSConfig should have sensible defaults."""
+        config = ServerTLSConfig()
+        assert config.ciphers is None


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->
Providing an optional mode to enforce secure connections for llama-stack, using only FIPS-approved TLS cipher suites.

  - Add security_mode setting (development / production) to ServerConfig that enforces TLS with FIPS-approved cipher suites in production mode    
  - Fix JWT algorithm confusion vulnerability in OAuth2 auth provider by replacing untrusted header algorithm with a static FIPS-approved         
  allowlist (RS256/PS256/ES256 families)                                                                                                          
  - Fix introspection endpoint defaulting to ssl_ctxt=False (no TLS verification) — now defaults to system CA verification (True)                 
  - Add HSTS header middleware for all HTTPS responses                                                                                            
  - Add --security-mode and --insecure CLI flags to override config at startup                                                                    
  - Add production-mode guard that rejects verify_tls=False in auth provider config                                                               


<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->
Closes RHAIENG-1865

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->
  - Unit tests added for SecurityMode validation, HSTS middleware, FIPS cipher constants, and JWT algorithm allowlist                             
  - Existing OAuth2/JWKS tests updated to use RSA key pairs instead of HS256 symmetric keys
  - uv run pytest tests/unit/server/test_tls_config.py tests/unit/server/test_auth.py -x                                                          

<!-- For API changes, include:
1. A testing script (Python, curl, etc.) that exercises the new/modified endpoints
2. The output from running your script

Example:
```python
...
...
```

Output:
```
<paste actual output here>
```
-->
